### PR TITLE
Adds the RubyAlternate command

### DIFF
--- a/doc/help.txt
+++ b/doc/help.txt
@@ -37,3 +37,9 @@ With [packer.nvim](https://github.com/wbthomason/packer.nvim)
 4. :RubyRun                                               *ruby.nvim-:rubyrun*
 
 Runs current Ruby file in a floating window.
+
+
+==============================================================================
+5. :RubyAlternate                                   *ruby.nvim-:rubyalternate*
+
+Alternate between a Ruby file and its test file.

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -1,0 +1,39 @@
+==============================================================================
+1. ruby.nvim                                             *ruby.nvim-ruby.nvim*
+
+
+ruby.nvim
+
+
+Ruby development plugin for Neovim. Highly unstable.
+==============================================================================
+2. Installation                                       *ruby.nvim-installation*
+
+
+With [vim-plug](https://github.com/junegunn/vim-plug)
+
+>
+    Plug 'nvim-lua/plenary.nvim'
+    Plug 'vinibispo/ruby.nvim', {'for': 'ruby'}
+<
+
+
+With [packer.nvim](https://github.com/wbthomason/packer.nvim)
+
+>
+    use {
+        'vinibispo/ruby.nvim',
+        requires={'nvim-lua/plenary.nvim'},
+        ft = {'ruby'}
+    }
+<
+
+
+==============================================================================
+3. Commands                                               *ruby.nvim-commands*
+
+
+==============================================================================
+4. :RubyRun                                               *ruby.nvim-:rubyrun*
+
+Runs current Ruby file in a floating window.

--- a/ftplugin/ruby.lua
+++ b/ftplugin/ruby.lua
@@ -1,2 +1,3 @@
 local cmd = vim.cmd
 cmd([[command! -nargs=1 -complete=file RubyRun lua require("ruby.cmd").run(<f-args>)]])
+cmd([[command! RubyAlternate lua require("ruby.cmd").alternate()]])

--- a/lua/ruby/cmd.lua
+++ b/lua/ruby/cmd.lua
@@ -1,6 +1,8 @@
 -- command module
 local Job = require('plenary.job')
+local Path = require('plenary.path')
 local window = require('plenary.window.float')
+local util = require('ruby.util')
 local api = vim.api
 local fn = vim.fn
 local schedule_wrap = vim.schedule_wrap
@@ -20,6 +22,48 @@ M.run = function(file)
       api.nvim_chan_send(job_id, data .. "\r\n")
     end),
   }:start()
+end
+
+-- :RubyAlternate
+M.alternate = function()
+  local path = Path:new(vim.fn.expand('%'))
+  if path:exists() ~= true or string.match(path.filename, '%.rb$') == nil then
+    print('buffer is empty or file is not a ruby file')
+    return
+  end
+
+  local alternates = {}
+  local directories = {'app', 'lib'}
+  local base_name = util.base_file_name(path)
+
+  if string.match(path.filename, '_test%.rb$') ~= nil then
+    local new_name, _ = string.gsub(base_name, '_test%.rb$', '.rb')
+    for _, directory in pairs(directories) do
+      table.insert(alternates, util.get_alternate(path, directory, new_name))
+    end
+  elseif string.match(path.filename, '_spec%.rb$') ~= nil then
+    local new_name, _ = string.gsub(base_name, '_spec%.rb$', '.rb')
+    for _, directory in pairs(directories) do
+      table.insert(alternates, util.get_alternate(path, directory, new_name))
+    end
+  else
+    for _, opts in pairs({{'_test.rb', 'test'}, {'_spec.rb', 'spec'}}) do
+      local suffix = opts[1]
+      local directory = opts[2]
+      local new_name, _ = string.gsub(base_name, '%.rb$', suffix)
+      table.insert(alternates, util.get_alternate(path, directory, new_name))
+    end
+  end
+
+  for _, alternate in pairs(alternates) do
+    if Path:new(alternate):exists() == true then
+      vim.cmd('edit ' .. alternate)
+      return
+    end
+  end
+
+  vim.api.nvim_err_writeln('alternate file not found')
+  return
 end
 
 return M

--- a/lua/ruby/util.lua
+++ b/lua/ruby/util.lua
@@ -1,0 +1,61 @@
+-- util functions
+local Job = require("plenary.job")
+local Path = require("plenary.path")
+local M = {}
+
+local git_root = function(file)
+  local path = Path:new(file)
+  if path:exists() ~= true then
+    return nil
+  end
+
+  local opts = {
+    command = "git",
+    args = {"rev-parse", "--show-toplevel"},
+    cwd = path:parent(),
+  }
+  local job = Job:new(opts):sync()
+  if job == nil then
+    print("git noit installed or not in a git repository")
+    return nil
+  end
+
+  return job[1]
+end
+
+local split_path = function(path)
+  -- TODO try to read sep from Plenary to make it work in non-Unix OS:
+  -- https://github.com/nvim-lua/plenary.nvim/blob/8bae2c1fadc9ed5bfcfb5ecbd0c0c4d7d40cb974/lua/plenary/path.lua#L20-L31
+  local sep = "/"
+  local matches = {}
+
+  for match in (path .. sep):gmatch("(.-)" .. sep) do
+    table.insert(matches, match)
+  end
+
+  return matches
+end
+
+M.base_file_name = function(file_path)
+    local path = Path:new(file_path)
+    local parts = split_path(path)
+    return parts[#parts]
+end
+
+M.get_alternate = function(file_path, alternate_directory, alternate_name)
+  local git = git_root(file_path)
+  local path = Path:new(file_path):make_relative(git)
+  local parts = split_path(path)
+
+  parts[1] = alternate_directory
+  parts[#parts] = alternate_name
+  local alternate = Path:new(git):joinpath(unpack(parts))
+
+  if alternate:exists() ~= true then
+    return nil
+  end
+
+  return alternate.filename
+end
+
+return M


### PR DESCRIPTION
This PR suggests an implementation for the `:RubyAlternate` (and add a docs file).

The strategy is:

* If the current file path patern is `xpto/dir1/dir2/../file_test.rb`
   * tries to open `app/dir1/dir2/../file.rb`
   * or `lib/dir1/dir2/../file.rb`
* If the current file path patern  `xpto/dir1/dir2/../file_spec.rb`
    * tries to open `app/dir1/dir2/../file.rb`
    * or `lib/dir1/dir2/../file.rb`
* If the current file path patern  `xpto/dir1/dir2/../file.rb`
    * tries to open `test/dir1/dir2/../file_test.rb`
    * or `spec/dir1/dir2/../file_spec.rb`
    
There's a `TODO` in the `util.lua` that limits this functionality to Unix-based OS (or systems that uses `/` as a separator for the filesystem paths). Any idea about a better workaround? I linked in the comment the [snippet from Plenary that sorts that out](https://github.com/nvim-lua/plenary.nvim/blob/8bae2c1fadc9ed5bfcfb5ecbd0c0c4d7d40cb974/lua/plenary/path.lua#L20-L31), but it looks like a non-public function/variable.

https://user-images.githubusercontent.com/4732915/125647542-cc36b800-13d5-454c-be7b-2dae8ad708f1.mp4

