### PR TITLE
Adds :RubyTest command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,31 @@
 # ruby.nvim
 
-Ruby development plugin for Neovim. Highly unstable.
+Ruby development plug-in for Neovim. Highly unstable.
 
 # Motivation
 
-This is a personal exercise on moving features from [go.nvim](https://github.com/npxbr/go.nvim/) to ruby world, using latest features from Neovim. The idea is to try to use Lua as much as possible, without relying
-100% on Ruby 3rd party libs. Of course, some of them will still be needed, but
-the focus is to push Lua the most we can.
+This is a personal exercise on moving features from 
+[go.nvim](https://github.com/npxbr/go.nvim/) to the Ruby world, using latest
+features from Neovim. The idea is to try to use Lua as much as possible,
+without relying too much on Ruby 3rd party libraries. The focus is to push Lua
+the most we can.
+
+Example with [packer.nvim](https://github.com/wbthomason/packer.nvim/):
+
+```lua
+use {
+  'vinibispo/ruby.nvim',
+  ft = {'ruby'}, -- optional
+  requires = {'nvim-lua/plenary.nvim'},
+  config = function() -- optional
+    require("ruby_nvim").setup({
+      test_cmd = "ruby",  -- the default value
+      test_args = {},  -- the default value
+    })
+  end,
+}
+```
 
 # Disclaimer
 
-That is totally based on [go.nvim](https://github.com/npxbr/go.nvim)
-
+That is totally based on [go.nvim](https://github.com/npxbr/go.nvim).

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -30,16 +30,38 @@ With [packer.nvim](https://github.com/wbthomason/packer.nvim)
 
 
 ==============================================================================
-3. Commands                                               *ruby.nvim-commands*
+3. Configuration
+
+The plugin accepts optional configuration for the command and arguments to run
+the tests:
+
+>
+    require("ruby_nvim").setup({
+        test_cmd = "ruby", -- default
+        test_args = {}, -- default
+    })
+<
 
 
 ==============================================================================
-4. :RubyRun                                               *ruby.nvim-:rubyrun*
+4. Commands                                               *ruby.nvim-commands*
+
+
+==============================================================================
+5. :RubyRun                                               *ruby.nvim-:rubyrun*
 
 Runs current Ruby file in a floating window.
 
 
 ==============================================================================
-5. :RubyAlternate                                   *ruby.nvim-:rubyalternate*
+6. :RubyAlternate                                   *ruby.nvim-:rubyalternate*
 
 Alternate between a Ruby file and its test file.
+
+
+==============================================================================
+7. :RubyTest[!]                                          *ruby.nvim-:rubytest*
+
+Runs the tests for the currente file. If the file is not a test file, it tries
+to find the (alternate) test file. If run with `!` and it is a test file, runs
+only the test under the cursor.

--- a/ftplugin/ruby.lua
+++ b/ftplugin/ruby.lua
@@ -1,3 +1,4 @@
 local cmd = vim.cmd
 cmd([[command! -nargs=1 -complete=file RubyRun lua require("ruby_nvim.cmd").run(<f-args>)]])
 cmd([[command! RubyAlternate lua require("ruby_nvim.cmd").alternate()]])
+cmd([[command! -bang RubyTest lua require("ruby_nvim.cmd").test("<bang>")]])

--- a/lua/ruby_nvim/cmd.lua
+++ b/lua/ruby_nvim/cmd.lua
@@ -1,69 +1,92 @@
 -- command module
-local Job = require('plenary.job')
-local Path = require('plenary.path')
-local window = require('plenary.window.float')
-local util = require('ruby_nvim.util')
+local Job = require("plenary.job")
+local Path = require("plenary.path")
+local window = require("plenary.window.float")
+local ruby = require("ruby_nvim")
+local opts = require("ruby_nvim.opts")
+local util = require("ruby_nvim.util")
 local api = vim.api
 local fn = vim.fn
 local schedule_wrap = vim.schedule_wrap
 local M = {}
 
--- :RubyRun
-M.run = function(file)
+local no_file_or_not_rb_file = "buffer is empty or file is not a ruby file"
+
+local run_in_floating_window = function(cmd, args)
   local win = window.percentage_range_window(tonumber("0.8"), tonumber("0.8"))
   local job_id = api.nvim_open_term(win.bufnr, {})
-  Job:new{
-    "ruby",
-    fn.expand(file),
-    on_stdout = schedule_wrap(function(_, data)
-      api.nvim_chan_send(job_id, data .. "\r\n")
-    end),
-    on_stderr = schedule_wrap(function(_, data)
-      api.nvim_chan_send(job_id, data .. "\r\n")
-    end),
-  }:start()
+
+  Job:new(
+    {
+      command = cmd,
+      args = args,
+      on_stdout = schedule_wrap(
+        function(_, data)
+          api.nvim_chan_send(job_id, data .. "\r\n")
+        end
+      ),
+      on_stderr = schedule_wrap(
+        function(_, data)
+          api.nvim_chan_send(job_id, data .. "\r\n")
+        end
+      ),
+    }
+  ):start()
+end
+
+-- :RubyRun
+M.run = function(file)
+  run_in_floating_window("ruby", {fn.expand(file)})
 end
 
 -- :RubyAlternate
 M.alternate = function()
-  local path = Path:new(vim.fn.expand('%'))
-  if path:exists() ~= true or string.match(path.filename, '%.rb$') == nil then
-    print('buffer is empty or file is not a ruby file')
+  local path = Path:new(vim.fn.expand("%"))
+  if not path:exists() or not util.is_ruby(path) then
+    print("buffer is empty or file is not a ruby file")
     return
   end
 
-  local alternates = {}
-  local directories = {'app', 'lib'}
-  local base_name = util.base_file_name(path)
-
-  if string.match(path.filename, '_test%.rb$') ~= nil then
-    local new_name, _ = string.gsub(base_name, '_test%.rb$', '.rb')
-    for _, directory in pairs(directories) do
-      table.insert(alternates, util.get_alternate(path, directory, new_name))
-    end
-  elseif string.match(path.filename, '_spec%.rb$') ~= nil then
-    local new_name, _ = string.gsub(base_name, '_spec%.rb$', '.rb')
-    for _, directory in pairs(directories) do
-      table.insert(alternates, util.get_alternate(path, directory, new_name))
-    end
-  else
-    for _, opts in pairs({{'_test.rb', 'test'}, {'_spec.rb', 'spec'}}) do
-      local suffix = opts[1]
-      local directory = opts[2]
-      local new_name, _ = string.gsub(base_name, '%.rb$', suffix)
-      table.insert(alternates, util.get_alternate(path, directory, new_name))
-    end
+  local alternate = util.alternate(path)
+  if not alternate:exists() then
+    print("could not find an alternate file")
+    return
   end
 
-  for _, alternate in pairs(alternates) do
-    if Path:new(alternate):exists() == true then
-      vim.cmd('edit ' .. alternate)
+  vim.cmd("edit " .. alternate.filename)
+end
+
+-- :RubyTest
+M.test = function(current_line)
+  local current_line = current_line == "!"
+  local path = Path:new(vim.fn.expand("%"))
+
+  if not util.is_ruby(path) then
+    print(no_file_or_not_rb_file)
+    return
+  end
+
+  if not util.is_test(path) then
+    if current_line then
+      print("not in a test file")
       return
+    else
+      path = util.alternate(path)
     end
   end
 
-  vim.api.nvim_err_writeln('alternate file not found')
-  return
+  if not path then
+    print("could not find a test file")
+    return
+  end
+
+  local args = vim.deepcopy(opts.load("test_args"))
+  table.insert(args, fn.expand(path.filename))
+  if current_line then
+    args[#args] = args[#args] .. ":" .. vim.api.nvim_win_get_cursor(0)[1]
+  end
+
+  run_in_floating_window(opts.load("test_cmd"), args)
 end
 
 return M

--- a/lua/ruby_nvim/init.lua
+++ b/lua/ruby_nvim/init.lua
@@ -1,0 +1,8 @@
+local opts = require("ruby_nvim.opts")
+local M = {}
+
+M.setup = function(user_options)
+  opts.configure(user_options)
+end
+
+return M

--- a/lua/ruby_nvim/opts.lua
+++ b/lua/ruby_nvim/opts.lua
@@ -1,0 +1,13 @@
+local defaults = {test_cmd = "ruby", test_args={}}
+local options = vim.deepcopy(defaults)
+local M = {}
+
+M.configure = function(user_options)
+  options = vim.tbl_extend("force", options, user_options)
+end
+
+M.load = function(key)
+  return options[key]
+end
+
+return M

--- a/lua/ruby_nvim/util.lua
+++ b/lua/ruby_nvim/util.lua
@@ -3,6 +3,7 @@ local Job = require("plenary.job")
 local Path = require("plenary.path")
 local M = {}
 
+-- local functions
 local git_root = function(file)
   local path = Path:new(file)
   if path:exists() ~= true then
@@ -31,13 +32,13 @@ local split_path = function(path)
   return matches
 end
 
-M.base_file_name = function(file_path)
-    local path = Path:new(file_path)
-    local parts = split_path(path)
-    return parts[#parts]
+local base_file_name = function(file_path)
+  local path = Path:new(file_path)
+  local parts = split_path(path)
+  return parts[#parts]
 end
 
-M.get_alternate = function(file_path, alternate_directory, alternate_name)
+local get_alternate = function(file_path, alternate_directory, alternate_name)
   local git = git_root(file_path)
   local path = Path:new(file_path):make_relative(git)
   local parts = split_path(path)
@@ -46,11 +47,52 @@ M.get_alternate = function(file_path, alternate_directory, alternate_name)
   parts[#parts] = alternate_name
   local alternate = Path:new(git):joinpath(unpack(parts))
 
-  if alternate:exists() ~= true then
+  if not alternate:exists() then
     return nil
   end
 
-  return alternate.filename
+  return alternate
+end
+
+-- public functions
+M.is_ruby = function(path)
+  return path:exists() and string.match(path.filename, "%.rb$")
+end
+
+M.is_test = function(path)
+  return string.match(path.filename, "_test%.rb$") or
+           string.match(path.filename, "_spec%.rb$")
+end
+
+M.alternate = function(path)
+  local alternates = {}
+  local directories = {"app", "lib"}
+  local base_name = base_file_name(path)
+
+  if string.match(path.filename, "_test%.rb$") then
+    local alternate, _ = string.gsub(base_name, "_test%.rb$", ".rb")
+    for _, directory in pairs(directories) do
+      table.insert(alternates, get_alternate(path, directory, alternate))
+    end
+  elseif string.match(path.filename, "_spec%.rb$") then
+    local alternate, _ = string.gsub(base_name, "_spec%.rb$", ".rb")
+    for _, directory in pairs(directories) do
+      table.insert(alternates, get_alternate(path, directory, alternate))
+    end
+  else
+    for _, opts in pairs({{"_test.rb", "test"}, {"_spec.rb", "spec"}}) do
+      local suffix = opts[1]
+      local directory = opts[2]
+      local new_name, _ = string.gsub(base_name, "%.rb$", suffix)
+      table.insert(alternates, get_alternate(path, directory, new_name))
+    end
+  end
+
+  for _, alternate in pairs(alternates) do
+    if alternate:exists() then
+      return alternate
+    end
+  end
 end
 
 return M


### PR DESCRIPTION
This PR suggests an implementation for `:RubyTest` — ~~it is marked as draft because it is not working locally, it throws an _Executable not found_ error that I believe is not a `ruby.nvim` problem, but something from my local setup. Can anyone help me with that?~~ Fixed. Thanks, @ellisonleao!

**TLDR**
 
* `:RubyTest` runs the current test file or the test of the current file's [alternate](https://github.com/vinibispo/ruby.nvim/pull/1)
* `:RubyTest!` in a test file runs the test located at the cursor position

**Context**

* We added a `options.lua` to handle configuration plugins, so we can have different commands to execute the tests (for example, `require("ruby_nvim").setup({ test = "rspec" })` for Rspec).
* We added a `init.lua` to handle the `setup` call
* We moved the alternate logic to `utils.lua` so we use it in `:RubyAlternate` and in `:RubyTest[!]`