### PR TITLE
Fixes :RubyAlternate

### DIFF
--- a/lua/ruby_nvim/util.lua
+++ b/lua/ruby_nvim/util.lua
@@ -13,7 +13,7 @@ local git_root = function(file)
   local opts = {
     command = "git",
     args = {"rev-parse", "--show-toplevel"},
-    cwd = path:parent(),
+    cwd = path:parent().filename,
   }
   local job = Job:new(opts):sync()
   if job == nil then


### PR DESCRIPTION
It was raising `E731: using Dictionary as a String`. I couldn't test it thoroughly but I guess Plenary used to accept its [path object](https://github.com/nvim-lua/plenary.nvim#plenarypath) as `cwd` option in a job, but now it requires it to be a string. The `.filename` gets the path as a string.