### PR TITLE
feat: Add :RubyBrowseGem

### DIFF
--- a/ftplugin/ruby.lua
+++ b/ftplugin/ruby.lua
@@ -1,4 +1,6 @@
 local cmd = vim.cmd
-cmd([[command! -nargs=1 -complete=file RubyRun lua require("ruby_nvim.cmd").run(<f-args>)]])
+cmd(
+  [[command! -nargs=1 -complete=file RubyRun lua require("ruby_nvim.cmd").run(<f-args>)]])
 cmd([[command! RubyAlternate lua require("ruby_nvim.cmd").alternate()]])
 cmd([[command! -bang RubyTest lua require("ruby_nvim.cmd").test("<bang>")]])
+cmd([[command! -nargs=0 RubyBrowseGem lua require('ruby_nvim.cmd').browse_gem()]])

--- a/lua/ruby_nvim/cmd.lua
+++ b/lua/ruby_nvim/cmd.lua
@@ -84,7 +84,6 @@ M.test = function(current_line)
 end
 
 -- :RubyBrowseGem
-
 M.browse_gem = function()
   local line = api.nvim_get_current_line()
   local gem_index = line:find('gem')

--- a/lua/ruby_nvim/cmd.lua
+++ b/lua/ruby_nvim/cmd.lua
@@ -88,8 +88,8 @@ end
 M.browse_gem = function()
   local line = api.nvim_get_current_line()
   local gem_index = line:find('gem')
-  local gem_with_space_and_quote_length = ('gem' .. ' "'):len()
-  local quote_and_comma_length = ('",'):len()
+  local gem_with_space_and_quote_length = 5
+  local quote_and_comma_length = 2
   local comma_index = line:find(',')
   local gem_name = ''
   if not gem_index then

--- a/lua/ruby_nvim/cmd.lua
+++ b/lua/ruby_nvim/cmd.lua
@@ -87,8 +87,7 @@ end
 
 M.browse_gem = function()
   local line = api.nvim_get_current_line()
-  local gem_word = 'gem'
-  local gem_index = line:find(gem_word)
+  local gem_index = line:find('gem')
   local gem_with_space_and_quote_length = ('gem' .. ' "'):len()
   local quote_and_comma_length = ('",'):len()
   local comma_index = line:find(',')


### PR DESCRIPTION
Create ruby command to get a gem and go to where the gem is hosted (rubygems)

![Peek 2021-08-23 07-24](https://user-images.githubusercontent.com/48097622/130432393-072ab5ab-136d-4634-a55a-b899ea6b605a.gif)

---

If you wanna test this feature put on your `plugin.lua` the following command 
```lua
  use {
    'vinibispo/ruby.nvim',
    branch = 'feature/ruby_browse_gems',
    ft = {'ruby'}, -- optional
    requires = {'nvim-lua/plenary.nvim'},
    config = function() -- optional
      require("ruby_nvim").setup({
        test_cmd = "ruby", -- the default value
        test_args = {}, -- the default value
      })
    end,
  }
```