### PR TITLE
Allows RubyAlternate to work with test/lib/ and spec/lib/ files

### DIFF
--- a/lua/ruby_nvim/cmd.lua
+++ b/lua/ruby_nvim/cmd.lua
@@ -42,7 +42,7 @@ M.alternate = function()
   end
 
   local alternate = util.alternate(path)
-  if not alternate:exists() then
+  if alternate == nil then
     print("could not find an alternate file")
     return
   end

--- a/lua/ruby_nvim/util.lua
+++ b/lua/ruby_nvim/util.lua
@@ -17,7 +17,7 @@ local git_root = function(file)
   }
   local job = Job:new(opts):sync()
   if job == nil then
-    print("git noit installed or not in a git repository")
+    print("git not installed or not in a git repository")
     return nil
   end
 
@@ -32,26 +32,18 @@ local split_path = function(path)
   return matches
 end
 
-local base_file_name = function(file_path)
-  local path = Path:new(file_path)
-  local parts = split_path(path)
-  return parts[#parts]
+local get_alternate = function(alternate_directory, alternate_name, context)
+  context.path[1] = alternate_directory
+  context.path[#context.path] = alternate_name
+  return Path:new(context.git_root):joinpath(unpack(context.path))
 end
 
-local get_alternate = function(file_path, alternate_directory, alternate_name)
-  local git = git_root(file_path)
-  local path = Path:new(file_path):make_relative(git)
-  local parts = split_path(path)
-
-  parts[1] = alternate_directory
-  parts[#parts] = alternate_name
-  local alternate = Path:new(git):joinpath(unpack(parts))
-
-  if not alternate:exists() then
-    return nil
+local test_suffix = function(directory, regex)
+  if regex then
+    return "_" .. directory .. "%.rb$"
   end
 
-  return alternate
+  return "_" .. directory .. ".rb"
 end
 
 -- public functions
@@ -64,33 +56,47 @@ M.is_test = function(path)
            string.match(path.filename, "_spec%.rb$")
 end
 
-M.alternate = function(path)
-  local alternates = {}
-  local directories = {"app", "lib"}
-  local base_name = base_file_name(path)
+M.alternate = function(file_path)
+  local path = Path:new(file_path)
+  local git = git_root(path)
+  path = path:make_relative(git)
 
-  if string.match(path.filename, "_test%.rb$") then
-    local alternate, _ = string.gsub(base_name, "_test%.rb$", ".rb")
-    for _, directory in pairs(directories) do
-      table.insert(alternates, get_alternate(path, directory, alternate))
-    end
-  elseif string.match(path.filename, "_spec%.rb$") then
-    local alternate, _ = string.gsub(base_name, "_spec%.rb$", ".rb")
-    for _, directory in pairs(directories) do
-      table.insert(alternates, get_alternate(path, directory, alternate))
-    end
-  else
-    for _, opts in pairs({{"_test.rb", "test"}, {"_spec.rb", "spec"}}) do
-      local suffix = opts[1]
-      local directory = opts[2]
-      local new_name, _ = string.gsub(base_name, "%.rb$", suffix)
-      table.insert(alternates, get_alternate(path, directory, new_name))
+  local parts = split_path(path)
+  local base_name = parts[#parts]
+  local context = {git_root = git_root(path), path = parts}
+
+  local main_directories = {"app", "lib", ""}
+  local test_directories = {"test", "spec"}
+  local test_subdirectories = {nil, "lib"}
+
+  for _, test_directory in pairs(test_directories) do
+    local suffix_regex = test_suffix(test_directory, true)
+
+    if string.match(base_name, suffix_regex) then
+      local alternate, _ = string.gsub(base_name, suffix_regex, ".rb")
+
+      for _, directory in pairs(main_directories) do
+        local alternate = get_alternate(directory, alternate, context)
+        if alternate:exists() then
+          return alternate
+        end
+      end
     end
   end
 
-  for _, alternate in pairs(alternates) do
-    if alternate:exists() then
-      return alternate
+  for _, directory in pairs(test_directories) do
+    local suffix = test_suffix(directory)
+    local new_name, _ = string.gsub(base_name, "%.rb$", suffix)
+
+    for _, subdirectory in pairs(test_subdirectories) do
+      if subdirectory ~= nil then
+        directory = directory .. Path.path.sep .. subdirectory
+      end
+
+      local alternate = get_alternate(directory, new_name, context)
+      if alternate:exists() then
+        return alternate
+      end
     end
   end
 end


### PR DESCRIPTION
This PR fixes a bug in `:RubyAlternate`: if one had, for example, `lib/service/user.rb` and `spec/lib/service_spec.rb` (same for `test` named files and directory), it would fail to alternate between these two files. Now it works ✨ 

Long story short, for `lib/service/user.rb` it would only try `test/service/user_test.rb` (or the equivalent using `spec`). Now it looks for both `test/service/user_test.rb` and `test/lib/service/user_test.rb`.

Also, this PR includes minor fixes and optimizations:
* `:RubyAlternate` is more memory efficient using early returns instead of accumulating possible results in a table
* `:RubyAlternate` is faster because now it avoids duplicated calls to secondary functions (`Path:new(path)`, `git_root` etc.)
* Fix bug that prevented the _could not find an alternate file_ message to show