### PR TITLE
Install Plenary in a temporary directory (by default)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: run tests
         run: make test
+        env:
+          PLENARY_DIR: vendor/plenary.nvim
 
   stylua:
     name: formatter

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-vendor/plenary.nvim

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,6 @@
 .PHONY: test prepare
 
-prepare:
-	@if [ ! -d "./vendor/plenary.nvim" ]; then git clone https://github.com/nvim-lua/plenary.nvim vendor/plenary.nvim; fi
-
-test: prepare
+test:
 	@nvim \
 		--headless \
 		--noplugin \

--- a/tests/minimal_vim.vim
+++ b/tests/minimal_vim.vim
@@ -1,5 +1,10 @@
+let $plenary_dir = empty($PLENARY_DIR) ? '/tmp/plenary.nvim' : $PLENARY_DIR
+if !isdirectory($plenary_dir)
+  echom system(['git', 'clone', 'https://github.com/nvim-lua/plenary.nvim', $plenary_dir])
+endif
+
 set rtp+=.
-set rtp+=vendor/plenary.nvim
+set rtp+=$plenary_dir
 
 runtime plugin/plenary.vim
 runtime plugin/ruby.vim


### PR DESCRIPTION
In #15 I think we added more than we needed:
* a `.gitignore`
* a prepare command in `Makefile`
* a local directory called `vendor/`

This PR suggests installing PLenary by default in `/tmp/plenary.nvim`. Setting an envvar `PLENARY_DIR` changes that behavior, and we use this in GitHub Actions (I've heard they don't let us use `/tmp`). This eliminates all the three additions listed above ; )
